### PR TITLE
internal/go-update: fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+internal/go-update/internal/binarydist/test*

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/equinox-io/equinox
+
+go 1.13


### PR DESCRIPTION
This is the same change Alan made in 2016 (!) but I preserve
parallelism and fix the tests instead.