### PR TITLE
Update GoDOC URL

### DIFF
--- a/internal/go-update/internal/binarydist/Readme.md
+++ b/internal/go-update/internal/binarydist/Readme.md
@@ -4,4 +4,4 @@ Package binarydist implements binary diff and patch as described on
 <http://www.daemonology.net/bsdiff/>. It reads and writes files
 compatible with the tools there.
 
-Documentation at <http://go.pkgdoc.org/github.com/kr/binarydist>.
+Documentation at <https://pkg.go.dev/github.com/kr/binarydist>.


### PR DESCRIPTION
Update GoDOC URL:
http://go.pkgdoc.org/github.com/kr/binarydist -> https://pkg.go.dev/github.com/kr/binarydist